### PR TITLE
handleDirectory() condition wrong?

### DIFF
--- a/apps/Backend/Modules/Jobs/Scan.php
+++ b/apps/Backend/Modules/Jobs/Scan.php
@@ -296,7 +296,7 @@ class Scan extends Job
         $directoryArray = explode(DIRECTORY_SEPARATOR, $path);
         $total          = count($directoryArray);
 
-        if (count($total) < 1)
+        if ($total) < 1)
         {
             return;
         }


### PR DESCRIPTION
I already opened this issue in comments and we started discussion about it but can not find the comment again so i open a issue for this.

Please check if my commit is correct. From my understanding it is and the previous variant would return 1 all the time.

"If the parameter is not an array or not an object with implemented Countable interface, 1 will be returned"

So the condition would not make any sense at all:

```
if (1 < 1) {
// do anything
}
```